### PR TITLE
FIX Now default image size will display in IE8 and lower

### DIFF
--- a/templates/Includes/ResponsiveImageSet.ss
+++ b/templates/Includes/ResponsiveImageSet.ss
@@ -1,7 +1,10 @@
 <span data-picture data-alt="$Title">
-	<% loop $Sizes %>
+    <% loop $Sizes %>
     <span data-src="$Image.URL" data-media="$Query"></span>
     <% end_loop %>
+    <!--[if (lt IE 9) & (!IEMobile)]>
+      <span data-src="$DefaultImage.URL"></span>
+    <![endif]-->
     <noscript>
         <img src="$DefaultImage.URL" alt="$Title">
     </noscript>


### PR DESCRIPTION
Currently this module doesn't work with IE8 and lower as they do not support media queries so each size with "data-media=" will not load. This adds an IE conditional line to the template which will display the default size. This technique was demonstrated on the picturefill.js docs https://github.com/scottjehl/picturefill#supporting-ie-desktop
