### PR TITLE
Compatibility update with FocusPoint 2.2.0

### DIFF
--- a/code/ResponsiveImageExtension.php
+++ b/code/ResponsiveImageExtension.php
@@ -110,6 +110,12 @@ class ResponsiveImageExtension extends \Extension
                 throw new Exception("Responsive set $set doesn't have any arguments provided for the query: $query");
             }
 
+            if (\ClassInfo::exists('FocusPointImage') && $methodName == 'CroppedFocusedImage') {
+                $cropData = $this->owner->calculateCrop($args[0], $args[1]);
+                $args[] = $cropData['CropAxis'];
+                $args[] = $cropData['CropOffset'];
+            }
+
             array_unshift($args, $methodName);
             $image = call_user_func_array(array($this->owner, 'getFormattedImage'), $args);
             $sizes->push(ArrayData::create(array(
@@ -121,6 +127,14 @@ class ResponsiveImageExtension extends \Extension
         // The first argument may be an image method such as 'CroppedImage'
         if (!isset($defaultArgs[0]) || !$this->owner->hasMethod($defaultArgs[0])) {
             array_unshift($defaultArgs, $methodName);
+        }
+         
+        if (\ClassInfo::exists('FocusPointImage') && $methodName == 'CroppedFocusedImage') {
+            if ($this->owner->hasMethod('calculateCrop')) {
+                $cropData = $this->owner->calculateCrop($defaultArgs[1], $defaultArgs[2]);
+                $defaultArgs[] = $cropData['CropAxis'];
+                $defaultArgs[] = $cropData['CropOffset'];
+            }
         }
 
         $image = call_user_func_array(array($this->owner, 'getFormattedImage'), $defaultArgs);


### PR DESCRIPTION
Compatibility with jonom/focuspoint 2.2.0 when using method CroppedFocusedImage (https://github.com/jonom/silverstripe-focuspoint).

When using method CroppedFocusedImage there is an error:
`ErrorException (E_UNKNOWN)
Missing argument 4 for FocusPointImage::generateCroppedFocusedImage()`

We updated module with missing arguments and checked it with conditional logic if module FocusPoint is present.
