### PR TITLE
Allow template overrides for individual image sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Heyday\ResponsiveImages\ResponsiveImageExtension:
         '(min-width: 200px)': [100]
 
     ResponsiveSet2:
+      template: Includes/MyCustomImageTemplate
       method: Fill
       arguments:
         '(min-width: 1000px) and (min-device-pixel-ratio: 2.0)': [1800, 1800]
@@ -100,6 +101,3 @@ It can also be passed into your template function.
 ```
 $MyImage.MyResponsiveSet('Fill', 800, 600)
 ```
-
-
-

--- a/code/ResponsiveImageExtension.php
+++ b/code/ResponsiveImageExtension.php
@@ -130,11 +130,13 @@ class ResponsiveImageExtension extends Extension
             ]));
         }
 
+        $templatePath = isset($config['template']) ? $config['template'] : 'Includes/ResponsiveImageSet';
+
         return $this->owner->customise([
             'Sizes' => $sizes,
 
             'DefaultImage' => $this->getResampledImage($methodName, $defaultArgs)
-        ])->renderWith('Includes/ResponsiveImageSet');
+        ])->renderWith($templatePath);
     }
 
     /**


### PR DESCRIPTION
For cases where one image template does not work for all cases of responsive images across a site.