### PR TITLE
UPDATE: Use vendor directory for composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "heyday/silverstripe-responsive-images",
     "description": "Configure and send a series of image size options to the client without loading any resources until a media query can be executed.",
     "keywords": ["silverstripe", "responsive", "image", "picturefill"],
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "license": "MIT",
     "require": {
         "silverstripe/framework": "^4.0"


### PR DESCRIPTION
Modify the type to make the module install inside the `vendor` path.