### PR TITLE
Allow for flexible module location using vendor-expose

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,3 +1,0 @@
-<?php
-
-define('RESPONSIVE_IMAGES_DIR', dirname(__FILE__));

--- a/code/ResponsiveImageExtension.php
+++ b/code/ResponsiveImageExtension.php
@@ -88,7 +88,7 @@ class ResponsiveImageExtension extends Extension
      */
     protected function createResponsiveSet($config, $defaultArgs, $set)
     {
-        Requirements::javascript(RESPONSIVE_IMAGES_DIR . '/javascript/picturefill/picturefill.min.js');
+        Requirements::javascript('heyday/silverstripe-responsive-images:javascript/picturefill/picturefill.min.js');
 
         if (!isset($config['arguments']) || !is_array($config['arguments'])) {
             throw new Exception("Responsive set $set does not have any arguments defined in its config.");

--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,20 @@
     "name": "heyday/silverstripe-responsive-images",
     "description": "Configure and send a series of image size options to the client without loading any resources until a media query can be executed.",
     "keywords": ["silverstripe", "responsive", "image", "picturefill"],
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "license": "MIT",
     "require": {
+        "silverstripe/vendor-plugin": "^1.0",
         "silverstripe/framework": "^4.0"
+    },
+    "extra": {
+        "expose": [
+            "javascript"
+        ]
+    },
+    "autoload": {
+        "psr-4": {
+            "Heyday\\ResponsiveImages\\": "code/"
+        }
     }
 }


### PR DESCRIPTION
-  Minimal updates to enable the use of `composer vendor-expose ` and a `public` path

- Addresses issues and squashes commits from fractaslabs PR at https://github.com/heyday/silverstripe-responsive-images/pull/21

- Removes _config.php entirely, as it was empty and we have _config path which should be enough to identify module