### PR TITLE
FIX: Extension should also be applied to DBFile

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,3 +4,6 @@ Name: responsiveimages
 SilverStripe\Assets\Image:
   extensions:
     - Heyday\ResponsiveImages\ResponsiveImageExtension
+SilverStripe\Assets\Storage\DBFile:
+  extensions:
+    - Heyday\ResponsiveImages\ResponsiveImageExtension


### PR DESCRIPTION
See docs here: https://docs.silverstripe.org/en/4/developer_guides/files/images/#creating-custom-image-functions

The reason is that performing an image manipulation returns a `DBFile`, so without this fix it’s impossible to add a responsive image set to the end of an image chain - e.g. `$Image.Quality(100).CarouselSet`.