### PR TITLE
Change default method

### DIFF
--- a/code/ResponsiveImageExtension.php
+++ b/code/ResponsiveImageExtension.php
@@ -39,7 +39,7 @@ class ResponsiveImageExtension extends Extension
      * @var string
      * @config
      */
-    private static $default_method = 'SetWidth';
+    private static $default_method = 'ScaleWidth';
 
     /**
      * @var string


### PR DESCRIPTION
The Image class no longer has a 'setWidth()' method, so leaving the method config option blank (as shown in one of the examples) results in an error on SS4.2
"Uncaught RuntimeException: SilverStripe\Assets\Image has no method SetWidth"

Changing to 'ScaleWidth' as the default cures the problem